### PR TITLE
Fixed a documentation bug ...

### DIFF
--- a/docs/mllib-statistics.md
+++ b/docs/mllib-statistics.md
@@ -445,7 +445,7 @@ val sc: SparkContext = ...
 // standard normal distribution `N(0, 1)`, evenly distributed in 10 partitions.
 val u = normalRDD(sc, 1000000L, 10)
 // Apply a transform to get a random double RDD following `N(1, 4)`.
-val v = u.map(x => 1.0 + 2.0 * x)
+val v = u.map(x => 1.0 + 3.0 * x)
 {% endhighlight %}
 </div>
 
@@ -469,7 +469,7 @@ JavaDoubleRDD u = normalJavaRDD(jsc, 1000000L, 10);
 JavaDoubleRDD v = u.map(
   new Function<Double, Double>() {
     public Double call(Double x) {
-      return 1.0 + 2.0 * x;
+      return 1.0 + 3.0 * x;
     }
   });
 {% endhighlight %}
@@ -490,7 +490,7 @@ sc = ... # SparkContext
 # standard normal distribution `N(0, 1)`, evenly distributed in 10 partitions.
 u = RandomRDDs.uniformRDD(sc, 1000000L, 10)
 # Apply a transform to get a random double RDD following `N(1, 4)`.
-v = u.map(lambda x: 1.0 + 2.0 * x)
+v = u.map(lambda x: 1.0 + 3.0 * x)
 {% endhighlight %}
 </div>
 


### PR DESCRIPTION
In order to get results in an intervall N (1 ...  4) we have to multiply the evenly distributed values with 3 (which is the interval length) instead of 2.0. 

v = u.map(lambda x: 1.0 + 3.0 \* x)

Example: 
min:   1 + 3 \* 0 = 1 
max:  1 + 3 \* 1 = 4

The wrong formula was: 
v = u.map(lambda x: 1.0 + 2.0 \* x)

Example: 
min:   1 + 2 \* 0 = 1  - OK
max:  1 + 2 \* 1 = 3  - WRONG

We would never see values larger than 3 in this example.
